### PR TITLE
Revert "Revert "Bump rack-protection from 1.5.2 to 1.5.5 in /api/ruby/building-a-ci-server"

### DIFF
--- a/api/ruby/building-a-ci-server/Gemfile.lock
+++ b/api/ruby/building-a-ci-server/Gemfile.lock
@@ -9,7 +9,7 @@ GEM
     octokit (3.0.0)
       sawyer (~> 0.5.3)
     rack (1.6.11)
-    rack-protection (1.5.2)
+    rack-protection (1.5.5)
       rack
     sawyer (0.5.4)
       addressable (~> 2.3.5)


### PR DESCRIPTION
Reverts Juaneduardo90-A-Byte/platform-samples#10